### PR TITLE
Fix TypeError: context.msg.replace is not a function, when input is a number

### DIFF
--- a/src/Bot.js
+++ b/src/Bot.js
@@ -91,7 +91,7 @@ class Bot extends EventEmitter {
 
         this.on('textmessage', (context) => {
           if (context.invokeruid !== this.options.user) {
-            const args = context.msg.replace(/\s+/g, ' ').trim().split(' ');
+            const args = context.msg.toString().replace(/\s+/g, ' ').trim().split(' ');
 
             if (Object.keys(this.commands).indexOf(args[0]) !== -1) {
               this.commands[args[0]].process(args, context);


### PR DESCRIPTION
… number.

Full error:
```/root/node_modules/cmr1-ts3-bot/src/Bot.js:94
                        const args = context.msg.replace(/\s+/g, ' ').trim().split(' ');
                                                 ^

TypeError: context.msg.replace is not a function
    at Bot.on (/root/node_modules/cmr1-ts3-bot/src/Bot.js:94:50)
    at Bot.EventEmitter.emit (/root/node_modules/eventemitter2/lib/eventemitter2.js:318:19)
    at getChannelById (/root/node_modules/cmr1-ts3-bot/src/Bot.js:141:26)
    at Bot.getChannelById (/root/node_modules/cmr1-ts3-bot/src/Bot.js:248:20)
    at getClientById (/root/node_modules/cmr1-ts3-bot/src/Bot.js:138:22)
    at _query (/root/node_modules/cmr1-ts3-bot/src/Bot.js:218:28)
    at Object.ts3.send [as cb] (/root/node_modules/cmr1-ts3-bot/src/Bot.js:405:20)
    at TeamSpeak._on_data (/root/node_modules/node-teamspeak-api/lib/teamspeak.js:219:25)
    at LineInputStream.<anonymous> (/root/node_modules/node-teamspeak-api/lib/teamspeak.js:181:18)
    at emitOne (events.js:116:13)
    at LineInputStream.emit (events.js:211:7)
    at LineInputStream.line (/root/node_modules/line-input-stream/lib/line-input-stream.js:8:8)
    at Array.forEach (<anonymous>)
    at Socket.<anonymous> (/root/node_modules/line-input-stream/lib/line-input-stream.js:36:9)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)```